### PR TITLE
Build app instead of `go run`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,4 +11,7 @@ WORKDIR /usr/src/app
 # Installing dependencies/
 RUN go mod download
 
-CMD ["go", "run", "main.go"]
+# Build the app
+RUN go build -o app .
+
+CMD ["./app"]


### PR DESCRIPTION
## Description

Performance-wise, it's better to build the app first, then run it.

## Steps

- [ ] My change requires a change to the documentation
- [ ] I have updated the accessible documentation according
- [x] I have read the **CONTRIBUTING.md** file
- [x] There is no duplicate open or closed pull request for this fix/addition/issue resolution.

## Original Issue

This PR resolves #ISSUE_NUMBER_HERE

<!--
Example:
This PR resolves #22
-->

<!--
Thank you for your contribution to PROJECT_NAME!
-->
